### PR TITLE
Notification Pressing

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,20 +2,21 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="MainActivity">
-        <State />
-      </entry>
-      <entry key="StaticProfilePagePreview">
-        <State />
-      </entry>
-      <entry key="SignIn">
-        <State />
-      </entry>
-      <entry key="StaticProfilePagePreview">
-        <State />
-      </entry>
       <entry key="app">
-        <State />
+        <State>
+          <runningDeviceTargetSelectedWithDropDown>
+            <Target>
+              <type value="RUNNING_DEVICE_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="SERIAL_NUMBER" />
+                  <value value="R5CT22P9LKT" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </runningDeviceTargetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-12-02T20:03:45.146182400Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/app/src/main/java/com/example/shpe_uf_mobile_kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/shpe_uf_mobile_kotlin/MainActivity.kt
@@ -13,6 +13,7 @@ package com.example.shpe_uf_mobile_kotlin
 //import com.example.shpe_uf_mobile_kotlin.ui.pages.register.RegistrationPage1
 //import com.example.shpe_uf_mobile_kotlin.ui.theme.SHPEUFMobileKotlinTheme
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -35,6 +36,7 @@ import com.example.shpe_uf_mobile_kotlin.repository.EventRepository
 import com.example.shpe_uf_mobile_kotlin.repository.NotificationRepository
 import com.example.shpe_uf_mobile_kotlin.ui.navigation.BottomNavigationBar
 import com.example.shpe_uf_mobile_kotlin.ui.navigation.NavHostContainer
+import com.example.shpe_uf_mobile_kotlin.ui.pages.home.HomeViewModel
 import com.example.shpe_uf_mobile_kotlin.ui.pages.home.HomeViewModelFactory
 import com.example.shpe_uf_mobile_kotlin.ui.pages.profile.ProfileViewModel
 import com.example.shpe_uf_mobile_kotlin.ui.pages.register.RegisterPage1ViewModel
@@ -46,6 +48,11 @@ class MainActivity() : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Get notification intent, aka the notif we pressed.
+        val notificationName = intent.getStringExtra("notification_name")
+        Log.d("NotificationsTest", "Main: ${notificationName.toString()}")
+
         setContent {
             SHPEUFMobileKotlinTheme {
                 val mainViewModel = initializeViewModel()
@@ -90,7 +97,7 @@ class MainActivity() : ComponentActivity() {
                             modifier = Modifier
                                 .padding(it),
                         ) {
-                            NavHostContainer(navController, viewModelFactory, mainViewModel, UserState, registerViewModel, profileViewModel)
+                            NavHostContainer(navController, viewModelFactory, mainViewModel, UserState, registerViewModel, profileViewModel, notificationName.toString())
                         }
                     }
                 }

--- a/app/src/main/java/com/example/shpe_uf_mobile_kotlin/data/DAO/EventDAO.kt
+++ b/app/src/main/java/com/example/shpe_uf_mobile_kotlin/data/DAO/EventDAO.kt
@@ -10,5 +10,8 @@ interface EventDao {
 
     @Query("SELECT * FROM events")
     suspend fun getAllEvents(): List<Event>
+
+    @Query("SELECT * FROM events WHERE summary = :summary LIMIT 1")
+    suspend fun getEventBySummary(summary: String): Event?
 }
 

--- a/app/src/main/java/com/example/shpe_uf_mobile_kotlin/repository/EventRepository.kt
+++ b/app/src/main/java/com/example/shpe_uf_mobile_kotlin/repository/EventRepository.kt
@@ -24,4 +24,8 @@ class EventRepository(context: Context) {
         return eventDao.getAllEvents().map { it.toHomeViewModelEvent() }
     }
 
+    suspend fun getEventBySummary(summary: String): HomeViewModel.Event? {
+        val event = eventDao.getEventBySummary(summary)
+        return event?.toHomeViewModelEvent()
+    }
 }

--- a/app/src/main/java/com/example/shpe_uf_mobile_kotlin/ui/navigation/SHPEUFNavController.kt
+++ b/app/src/main/java/com/example/shpe_uf_mobile_kotlin/ui/navigation/SHPEUFNavController.kt
@@ -139,7 +139,8 @@ fun NavHostContainer(
     mainViewModel: SHPEUFAppViewModel,
     userState: AppState,
     registerViewModel: RegisterPage1ViewModel,
-    profileViewModel: ProfileViewModel
+    profileViewModel: ProfileViewModel,
+    notificationSummary: String
 ) {
     val homeViewModel: HomeViewModel =
         viewModel(factory = homeViewModelFactory, key = "HomeViewModel")
@@ -150,6 +151,21 @@ fun NavHostContainer(
 
         navHostController.navigate(if(isLoggedIn) NavRoute.HOME else NavRoute.OPENING)
 
+    }
+
+    LaunchedEffect(notificationSummary) {
+        val event = homeViewModel.getEventBySummary(notificationSummary)
+        Log.d("NotificationsTest", "Passed In, Inside: $notificationSummary")
+        Log.d("NotificationsTest", "Event, Inside: $event")
+        Log.d ("NotificationsTest", "Event ID, Inside: ${event?.id}")
+        Log.d("NotificationsTest", "Event ID, Inside: ${event?.summary}")
+
+        if (event != null) {
+            Log.d("NotificationsTest", "Event ID, Inside: $notificationSummary")
+            homeViewModel.selectEvent(event)
+        }
+
+        navHostController.navigate(NavRoute.HOME)
     }
 
     NavHost(
@@ -197,7 +213,6 @@ fun NavHostContainer(
         {
             RegistrationPage3Preview(navController = navHostController, registerPage1ViewModel = registerViewModel )
         }
-
     }
 }
 

--- a/app/src/main/java/com/example/shpe_uf_mobile_kotlin/ui/pages/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/shpe_uf_mobile_kotlin/ui/pages/home/HomeViewModel.kt
@@ -131,7 +131,10 @@ class HomeViewModel(
         )
 
         // Apply updated events and notification settings to state
-        _homeUIState.value = homeState.value.copy(events = updatedEvents, notificationSettings = updatedNotificationSettings)
+        _homeUIState.value = homeState.value.copy(
+            events = updatedEvents,
+            notificationSettings = updatedNotificationSettings
+        )
 
         // Handle scheduling or canceling notifications
         handleNotificationsForEvents(updatedEvents, type, isEnabled)
@@ -139,21 +142,26 @@ class HomeViewModel(
     }
 
     fun toggleAllNotifications(context: Context) {
-        Log.d("HomeViewModel", "Currently all notifications are ${homeState.value.notificationSettings.allNotificationSelection}")
-        Log.d ("HomeViewModel", "Toggled all notifications")
+        Log.d(
+            "HomeViewModel",
+            "Currently all notifications are ${homeState.value.notificationSettings.allNotificationSelection}"
+        )
+        Log.d("HomeViewModel", "Toggled all notifications")
 
         // all starts as false
         val allNotificationOn = homeState.value.notificationSettings.allNotificationSelection
 
         _homeUIState.update { currentState ->
-            currentState.copy(notificationSettings = currentState.notificationSettings.copy(
-                gbmNotification = !allNotificationOn,
-                socialNotification = !allNotificationOn,
-                workshopNotification = !allNotificationOn,
-                infoSessionNotification = !allNotificationOn,
-                volunteeringNotification = !allNotificationOn,
-                allNotificationSelection = !allNotificationOn
-            ))
+            currentState.copy(
+                notificationSettings = currentState.notificationSettings.copy(
+                    gbmNotification = !allNotificationOn,
+                    socialNotification = !allNotificationOn,
+                    workshopNotification = !allNotificationOn,
+                    infoSessionNotification = !allNotificationOn,
+                    volunteeringNotification = !allNotificationOn,
+                    allNotificationSelection = !allNotificationOn
+                )
+            )
         }
 
         if (!allNotificationOn) {
@@ -166,8 +174,7 @@ class HomeViewModel(
             homeState.value.events.forEach { event ->
                 NotificationsUtil.scheduleNotification(event)
             }
-        }
-        else {
+        } else {
             // update color
             _homeUIState.update { currentState ->
                 currentState.copy(allNotificationCurrentColor = allNotificationsOff)
@@ -194,17 +201,21 @@ class HomeViewModel(
         }
     }
 
-    private fun handleNotificationsForEvents(events: List<Event>, type: EventType, isEnabled: Boolean) {
+    private fun handleNotificationsForEvents(
+        events: List<Event>,
+        type: EventType,
+        isEnabled: Boolean
+    ) {
         val notificationsUtil = NotificationsUtil
 
-        events.filter { it.eventType == type && it.notificationEnabled == isEnabled }.forEach { event ->
-            if (isEnabled) {
-                notificationsUtil.scheduleNotification(event)
+        events.filter { it.eventType == type && it.notificationEnabled == isEnabled }
+            .forEach { event ->
+                if (isEnabled) {
+                    notificationsUtil.scheduleNotification(event)
+                } else {
+                    notificationsUtil.cancelNotification(event)
+                }
             }
-            else {
-                notificationsUtil.cancelNotification(event)
-            }
-        }
     }
 
     private fun shouldScheduleNotification(event: HomeViewModel.Event): Boolean {
@@ -219,7 +230,11 @@ class HomeViewModel(
     }
 
     // Saving States for reboot
-    private fun saveNotificationSettings(context: Context, eventType: EventType, isEnabled: Boolean){
+    private fun saveNotificationSettings(
+        context: Context,
+        eventType: EventType,
+        isEnabled: Boolean
+    ) {
         val sharedPreferences = context.getSharedPreferences("AppSettings", Context.MODE_PRIVATE)
         with(sharedPreferences.edit()) {
             putBoolean(eventType.name, isEnabled)
@@ -254,6 +269,22 @@ class HomeViewModel(
         viewModelScope.launch {
             eventRepo.insert(event)
         }
+    }
+
+    suspend fun getEventBySummary(summary: String): Event? {
+        return eventRepo.getEventBySummary(summary)
+
+//        var event: Event? = null
+//        viewModelScope.launch {
+//            event = eventRepo.getEventBySummary(summary)
+//            Log.d("NotificationsTest", "Event: $event")
+//            if (event != null) {
+//                selectEvent(event)
+//            } else {
+//                Log.d("NotificationsTest", "Event not found")
+//            }
+//        }
+//        return event
     }
 
      fun eraseEvents() {


### PR DESCRIPTION
Can now press on notifications from outside or inside app and will open up the information of the event in question.

### Summary

In this PR a pending intent was added to be able to press on a notification outside or outside of the application. It will open up the app to the event details.

Another bug was fixed that would make notifications reappear after the event started until they were outside of the scope of the days obtained.

### Reference

[_Reference your Asana task here as shown below_
](https://app.asana.com/0/1205340802626919/1208493315139016/f)

### Extra
@Anthony-Zurita @TheAndreiUrsu @IsRo06 

